### PR TITLE
Add 404 page, move header image style to global

### DIFF
--- a/assets/css/_get-in-touch.sss
+++ b/assets/css/_get-in-touch.sss
@@ -1,12 +1,5 @@
 #get-in-touch
   @apply --standardPage
-
-  & .p-header-img
-    background-repeat: no-repeat
-    background-position: center center
-    background-size: cover
-    height: 0
-    padding-bottom: 56.25%
   
   & ul.p-contact
     list-style-type: none

--- a/assets/css/_global.sss
+++ b/assets/css/_global.sss
@@ -188,3 +188,10 @@ button.g-button:focus
 .hidden
   display: none
   opacity: 0
+
+.p-header-img
+  background-repeat: no-repeat
+  background-position: center center
+  background-size: cover
+  height: 0
+  padding-bottom: 56.25%

--- a/assets/css/_meet-our-team.sss
+++ b/assets/css/_meet-our-team.sss
@@ -3,14 +3,6 @@
 
   // Style overrides for specific content
 
-  & .p-header-img
-    background-repeat: no-repeat
-    background-position: center center
-    background-size: cover
-    height: 0
-    padding-bottom: 56.25%
-
-
   & h3
     margin-bottom: -1rem
 

--- a/assets/css/_upcoming-events.sss
+++ b/assets/css/_upcoming-events.sss
@@ -3,13 +3,6 @@
 
   // Style overrides for specific content
 
-  & .p-header-img
-    background-repeat: no-repeat
-    background-position: center center
-    background-size: cover
-    height: 0
-    padding-bottom: 56.25%
-
   & h3
     margin-bottom: -0.5rem
 

--- a/views/404.sgr
+++ b/views/404.sgr
@@ -1,0 +1,17 @@
+extends(src='layout.sgr')
+  block(name='pagemeta')
+    meta(name='description' content='Page not found')
+
+  block(name='title')
+    title Sorry, this page doesn't exist
+
+  block(name='content')
+    .p-header-img(role="img" aria-label="Dr. Forbes & Associates Contact Page Header" style="background-image: url(https://{{ dato._meta.imgixHost + dato.contact_page[0].contactHeaderImage.path }});")
+    .p-wrapper
+      .g-wrapper
+        h2 Page not found
+        p Sorry for the trouble, but the page you've requested doesn't exist. 
+        p Here are some things you can try:
+        ul
+          li: a(href="/") Go back to the homepage
+          li: a(href="/get-in-touch") Get in touch 


### PR DESCRIPTION
Realized we were missing a 404 page (Netlify automatically uses 404.html for errors. 

Also had header image style on a page level, but DRY, so moved to global styles and removed from pages.